### PR TITLE
Add rust generator to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ OpenAPI Forge currently has the following language generators:
 - C# - https://github.com/ScottLogic/openapi-forge-csharp
 - JavaScript - https://github.com/Scottlogic/openapi-forge-javascript
 - Java - https://github.com/ScottLogic/openapi-forge-java
+- Rust - https://github.com/ScottLogic/openapi-forge-rust
 
 # Generator development
 


### PR DESCRIPTION
Realised the `rust` generator is not mentioned in the forge `README`. This small PR adds it.